### PR TITLE
Update docker credential secrets usage

### DIFF
--- a/.github/workflows/workflow-release_task-deployDocker.yml
+++ b/.github/workflows/workflow-release_task-deployDocker.yml
@@ -9,8 +9,10 @@ on:
         default: false
         type: boolean
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
 
 jobs:
   docker_deploy:


### PR DESCRIPTION
This fixes a minor bug in how the docker credentials were being interpreted. Rather than setting it, it makes this a required secret for the downstream workflow to pass.