### PR TITLE
Updates versioning workflows

### DIFF
--- a/.github/actions/action-setup_task-installPyProject/action.yml
+++ b/.github/actions/action-setup_task-installPyProject/action.yml
@@ -10,7 +10,7 @@ inputs:
   cache-id:
     description: Reference id to define cache
     required: false
-    default: ${{ github.event.pull_request_id || github.event.after }}
+    default: ${{ github.event.pull_request.id || github.event.after }}
     type: string
   manager:
     description: Dependency manager used (e.g. poetry)

--- a/.github/actions/action-version_task-commit/action.yml
+++ b/.github/actions/action-version_task-commit/action.yml
@@ -1,0 +1,56 @@
+---
+# Should be used together with action-version_task-preRelease
+# (see workflow-version_task-semverGithub for example usage)
+#
+# Assumes:
+#   - main brain is protected
+name: Push to protected branch
+description: Push new changes / updates to a protected branch
+inputs:
+  version:
+    description: New / updated project version
+    required: false
+    type: string
+  bp-pat:
+    description: Personal access token to update branch protection
+    required: true
+    type: string
+  release:
+    description: Boolean flag to indicate part of Github release workflow
+    required: false
+    default: false
+    type: boolean
+  branch:
+    description: Triggering branch to checkout
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Commit updates
+      env:
+        VERSION: ${{ inputs.version }}
+      shell: bash
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git diff-index --quiet HEAD || git commit -m "Bump version to $VERSION" -
+
+    - name: Push changes
+      uses: CasperWA/push-protected@v2
+      with:
+        branch: ${{ github.event.pull_request.base.ref }}
+        token: ${{ secrets.BP-PAT }}
+        unprotect_reviews: true
+
+    - name: Publish changelog
+      uses: release-drafter/release-drafter@v5
+      if: ${{ inputs.release }} == 'true'
+      with:
+        commitish: ${{ inputs.branch }}
+        publish: true
+        name: ${{ inputs.version }}
+        tag: v${{ inputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.bp-pat }}

--- a/.github/actions/action-version_task-commit/action.yml
+++ b/.github/actions/action-version_task-commit/action.yml
@@ -35,13 +35,13 @@ runs:
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
-        git diff-index --quiet HEAD || git commit -m "Bump version to $VERSION" -
+        git diff-index --quiet HEAD || git commit -m "Bump version to $VERSION" -a
 
     - name: Push changes
       uses: CasperWA/push-protected@v2
       with:
         branch: ${{ github.event.pull_request.base.ref }}
-        token: ${{ secrets.BP-PAT }}
+        token: ${{ inputs.BP-PAT }}
         unprotect_reviews: true
 
     - name: Publish changelog

--- a/.github/actions/action-version_task-updatePrereleaseVersion/action.yml
+++ b/.github/actions/action-version_task-updatePrereleaseVersion/action.yml
@@ -1,0 +1,77 @@
+---
+# Should be used used together with action-version_task-commit
+# (see workflow-version_task-semverGithub for example usage)
+#
+# Assumes:
+#   - release-drafter is used to create release notes
+#     (see https://github.com/marketplace/actions/release-drafter)
+name: Get previous project version
+description: Get the last version from project metadata for prerelease
+inputs:
+  project-metadata:
+    description: Metadata file containing project version (e.g. pyproject.toml)
+    required: false
+    default: pyproject.toml
+    type: string
+  bp-pat:
+    description: Personal access token to update branch protection
+    required: true
+    type: string
+outputs:
+  new-version:
+    description: Next pre-release version
+    value: ${{ steps.update-semver.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.base.ref }}
+
+    - name: Update changelog
+      uses: release-drafter/release-drafter@v5
+      id: release-drafter
+      with:
+        commitish: ${{ github.event.pull_request.base.ref }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.bp-pat }}
+
+    - name: Get previous release version
+      env:
+        METADATA: ${{ inputs.project-metadata }}
+      shell: bash
+      run: |
+        echo "PREV_VER=$(cat $METADATA | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
+
+    - name: Get previous bump version
+      env:
+        PREV_VER: ${{ env.PREV_VER }}
+      shell: bash
+      run: |
+        if [[ "$PREV_VER" != *"-pre."* ]]; then
+          echo "OLD_BUMP=0" >> $GITHUB_ENV
+        else
+          echo "OLD_BUMP=$(echo $PREV_VER | cut -d '.' -f 4)" >> $GITHUB_ENV
+        fi
+
+    - name: Bump version
+      env:
+        BUMP_VER: ${{ env.OLD_BUMP }}
+      shell: bash
+      run: |
+        echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
+
+    - name: Set new release version
+      id: update-semver
+      env:
+        RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
+        BUMP_VER: ${{ env.NEW_BUMP }}
+      shell: bash
+      run: |
+        if [ ! -z "$RD_RELEASE" ]; then
+          echo "version=${RD_RELEASE}-pre-${BUMP_VER}" >> $GITHUB_OUTPUT
+        else
+          echo "version=0.1.0-pre-${BUMP_VER}" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/action-version_task-updateReleaseVersion/action.yml
+++ b/.github/actions/action-version_task-updateReleaseVersion/action.yml
@@ -1,0 +1,59 @@
+---
+# Should be used used together with action-version_task-commit
+# (see workflow-version_task-publishGithub for example usage)
+#
+# Assumes:
+#   - release-drafter is used to create release notes
+#     (see https://github.com/marketplace/actions/release-drafter)
+name: Get previous project version
+description: Get the last version from project metadata for release
+inputs:
+  project-metadata:
+    description: Metadata file containing project version (e.g. pyproject.toml)
+    required: false
+    default: pyproject.toml
+    type: string
+  bp-pat:
+    description: Personal access token to update branch protection
+    required: true
+    type: string
+outputs:
+  new-version:
+    description: Next pre-release version
+    value: ${{ steps.update-semver.outputs.version }}
+  branch:
+    description: Triggering branch
+    value: ${{ steps.extract-branch.outputs.branch }}
+
+runs:
+  using: composite
+  steps:
+    - name: Extract triggering branch
+      id: extract-branch
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+
+    - name: Checkout triggering branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ steps.extract-branch.outputs.branch }}
+
+    - name: Draft changelog
+      uses: release-drafter/release-drafter@v5
+      id: release-drafter
+      with:
+        commitish: ${{ steps.extract-branch-outputs.branch }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.bp-pat }}
+
+    - name: Set new release version
+      id: update-semver
+      env:
+        RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
+      shell: bash
+      run: |
+        if [ ! -z $RD_RELEASE" ]; then
+          echo "version=$RD_RELEASE" >> $GITHUB_OUTPUT
+        else
+          echo "version=0.1.0" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/workflow-release_task-publishGithub.yml
+++ b/.github/workflows/workflow-release_task-publishGithub.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: pyproject.toml
         type: string
+      pipeline-description:
+        description: Boolean flag to update pipeline_description.json
+        required: false
+        default: false
+        type: boolean
     secrets:
       BP-PAT:
         required: true
@@ -31,7 +36,7 @@ jobs:
 
       - name: Grab release version
         id: semver
-        uses: ./.github/actions/action-version_task-updateReleaseVersion
+        uses: khanlab/actions/.github/actions/action-version_task-updateReleaseVersion@v0.2.0
         with:
           project-metadata: ${{ inputs.project-metadata }}
           bp-pat: ${{ secrets.BP-PAT }}
@@ -43,8 +48,16 @@ jobs:
           find: version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"
           replace: version = "${{ steps.semver.outputs.new-version }}"
 
+      - name: Update pipeline description
+        if: inputs.pipeline-description
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          include: "**/pipeline_description.json"
+          find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: '"Version": "${{ steps.semver.outputs.new-version }}"'
+
       - name: Commit changes and publish changelog
-        uses: ./.github/actions/action-version_task-commit
+        uses: khanlab/actions/.github/actions/action-version_task-commit@v0.2.0
         with:
           version: ${{ steps.semver.outputs.new-version }}
           bp-pat: ${{ secrets.BP-PAT }}

--- a/.github/workflows/workflow-release_task-publishGithub.yml
+++ b/.github/workflows/workflow-release_task-publishGithub.yml
@@ -11,18 +11,13 @@ on:
         description: Comments
         required: false
         type: string
-      project_metadata:
+      project-metadata:
         description: File containing project metadata (e.g. pyproject.toml)
         required: false
         default: pyproject.toml
         type: string
-      pipeline_description:
-        description: Update pipeline description version
-        required: false
-        default: false
-        type: boolean
     secrets:
-      BP_PAT:
+      BP-PAT:
         required: true
 
 jobs:
@@ -34,69 +29,24 @@ jobs:
           echo "Author: ${{ github.triggering_actor }}"
           echo "Comments: ${{ inputs.comments }}"
 
-      - name: Extract branch
-        id: extract-branch
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-
-      - name: Checkout triggering branch
-        uses: actions/checkout@v3
+      - name: Grab release version
+        id: semver
+        uses: ./.github/actions/action-version_task-updateReleaseVersion
         with:
-          ref: ${{ steps.extract-branch.outputs.branch }}
+          project-metadata: ${{ inputs.project-metadata }}
+          bp-pat: ${{ secrets.BP-PAT }}
 
-      - name: Draft change log
-        uses: release-drafter/release-drafter@v5
-        id: release-drafter
-        with:
-          commitish: ${{ steps.extract-branch.outputs.branch }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set new release version
-        env:
-          RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
-        run: |
-          if [ ! -z "$RD_RELEASE" ]; then
-            echo "NEW_RELEASE=$RD_RELEASE" >> $GITHUB_ENV
-          else
-            echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
-          fi
-
-      - name: Update version in ${{ inputs.project_metadata }}
+      - name: Update version in ${{ inputs.project-metadata }}
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          include: ${{ inputs.project_metadata }}
+          include: ${{ inputs.project-metadata }}
           find: version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"
-          replace: version = "${{ env.NEW_RELEASE }}"
+          replace: version = "${{ steps.semver.outputs.new-version }}"
 
-      - name: Update pipeline description
-        if: inputs.pipeline_description
-        uses: jacobtomlinson/gha-find-replace@v3
+      - name: Commit changes and publish changelog
+        uses: ./.github/actions/action-version_task-commit
         with:
-          include: "**/pipeline_description.json"
-          find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
-          replace: '"Version": "${{ env.NEW_RELEASE }}"'
-
-      - name: Commit updates
-        env:
-          LATEST_VERSION: ${{ env.NEW_RELEASE }}
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
-
-      - name: Push changes
-        uses: CasperWA/push-protected@v2
-        with:
-          token: ${{ secrets.BP_PAT }}
-          unprotect_reviews: true
-
-      - name: Publish change log
-        uses: release-drafter/release-drafter@v5
-        with:
-          commitish: ${{ steps.extract-branch.outputs.branch }}
-          publish: true
-          name: ${{ env.NEW_RELEASE }}
-          tag: v${{ env.NEW_RELEASE }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.BP_PAT }}
+          version: ${{ steps.semver.outputs.new-version }}
+          bp-pat: ${{ secrets.BP-PAT }}
+          release: True
+          branch: ${{ steps.semver.outputs.branch }}

--- a/.github/workflows/workflow-version_task-semverGithub.yml
+++ b/.github/workflows/workflow-version_task-semverGithub.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: pyproject.toml
         type: string
+      pipeline-description:
+        description: Boolean flag to update pipeline_description.json
+        required: false
+        default: false
+        type: boolean
     secrets:
       BP-PAT:
         required: true
@@ -22,7 +27,7 @@ jobs:
     steps:
       - name: Grab previous version
         id: semver
-        uses: ./.github/actions/action-version_task-updatePrereleaseVersion
+        uses: khanlab/actions/.github/actions/action-version_task-updatePrereleaseVersion@maint/semver
         with:
           project-metadata: ${{ inputs.project-metadata }}
           bp-pat: ${{ secrets.BP-PAT }}
@@ -34,8 +39,16 @@ jobs:
           find: version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"
           replace: version = "${{ steps.semver.outputs.new-version }}"
 
+      - name: Update pipeline description
+        if: inputs.pipeline-description
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          include: "**/pipeline_description.json"
+          find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
+          replace: '"Version": "${{ steps.semver.outputs.new-version }}"'
+
       - name: Commit changes
-        uses: ./.github/actions/action-version_task-commit
+        uses: khanlab/actions/.github/actions/action-version_task-commit@v0.2.0
         with:
           version: ${{ steps.semver.outputs.new-version }}
           bp-pat: ${{ secrets.BP-PAT }}

--- a/.github/workflows/workflow-version_task-semverGithub.yml
+++ b/.github/workflows/workflow-version_task-semverGithub.yml
@@ -7,82 +7,35 @@ name: Bump version
 on:
   workflow_call:
     inputs:
-      project_metadata:
+      project-metadata:
         description: File containing project metadata (e.g. pyproject.toml)
         required: false
         default: pyproject.toml
         type: string
     secrets:
-      BP_PAT:
+      BP-PAT:
         required: true
 
 jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main branch
-        uses: actions/checkout@v3
+      - name: Grab previous version
+        id: semver
+        uses: ./.github/actions/action-version_task-updatePrereleaseVersion
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          project-metadata: ${{ inputs.project-metadata }}
+          bp-pat: ${{ secrets.BP-PAT }}
 
-      - name: Update changelog
-        uses: release-drafter/release-drafter@v5
-        id: release-drafter
-        with:
-          commitish: ${{ github.event.pull_request.base.ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.BP_PAT }}
-
-      - name: Get previous release version
-        env:
-          METADATA: ${{ inputs.project_metadata }}
-        run: |
-          echo "PREV_VER=$(cat $METADATA | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
-
-      - name: Get previous version
-        env:
-          PREV_VER: ${{ env.PREV_VER }}
-        run: |
-          if [[ "$PREV_VER" != *"-pre."* ]]; then
-            echo "OLD_BUMP=0" >> $GITHUB_ENV
-          else
-            echo "OLD_BUMP=$(echo $PREV_VER | cut -d '.' -f 4)" >> $GITHUB_ENV
-          fi
-
-      - name: Bump version
-        env:
-          BUMP_VER: ${{ env.OLD_BUMP }}
-        run: |
-          echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
-
-      - name: Set new release version
-        env:
-          RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
-        run: |
-          if [ ! -z "$RD_RELEASE" ]; then
-            echo "NEW_RELEASE=$RD_RELEASE" >> $GITHUB_ENV
-          else
-            echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
-          fi
-
-      - name: Update version in ${{ inputs.project_metadata }}
+      - name: Update version in ${{ inputs.project-metadata }}
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          include: ${{ inputs.project_metadata }}
+          include: ${{ inputs.project-metadata }}
           find: version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"
-          replace: version = "${{ env.NEW_RELEASE }}-pre.${{ env.NEW_BUMP }}"
+          replace: version = "${{ steps.semver.outputs.new-version }}"
 
-      - name: Commit updates
-        env:
-          APP_VERSION: ${{ env.NEW_RELEASE }}-pre.${{ env.NEW_BUMP }}
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git diff-index --quiet HEAD || git commit -m "Bump version to $APP_VERSION" -a
-
-      - name: Push changes
-        uses: CasperWA/push-protected@v2
+      - name: Commit changes
+        uses: ./.github/actions/action-version_task-commit
         with:
-          branch: ${{ github.event.pull_request.base.ref }}
-          token: ${{ secrets.BP_PAT }}
-          unprotect_reviews: true
+          version: ${{ steps.semver.outputs.new-version }}
+          bp-pat: ${{ secrets.BP-PAT }}


### PR DESCRIPTION
Splits up the pre-release and release version bumping workflows to make use of composite actions rather than making the versioning actions completely static. The benefit of this is that the version grabbing and commit actions can be separately called in other workflows (e.g. if files other than the metadata - pyproject.toml or pipeline_description.json needs to be updated). 