### PR TITLE
Add generic composite action to push to protected branch

### DIFF
--- a/.github/actions/action-general_task-commitProtected/action.yml
+++ b/.github/actions/action-general_task-commitProtected/action.yml
@@ -1,0 +1,48 @@
+---
+# A generic action that helps with pushing changes to a protected branch
+#
+# Assumes:
+#   - main branch is protected
+
+name: Push to protected branch
+description: Check and if necessary push new changes within workflow to a protected branch
+inputs:
+  branch:
+    description: Branch to commit changes to
+    required: true
+    type: string
+  commit-msg:
+    description: Commit message
+    required: true
+    type: string
+  bp-pat:
+    description: Personal access token to update branch protection
+    required: true
+    type: string
+
+runs:
+  using: composite:
+  steps:
+  - name: Check changes
+    run: |
+      gh_status=$(git status --porcelain)
+      if [ -z "$gh_status" ]; then
+        echo 'modified="false"' >> $GITHUB_ENV
+      else
+        echo 'modified="true"' >> $GITHUB_ENV
+      false
+  
+  - name: Commit changes
+    if: ${{ env.modified == 'true' }}
+    run: |
+      git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      git config --local user.name "github-actions[bot]"
+      git diff-index --quiet HEAD || git commit -m "[BOT] ${{ input.commit-msg }}" -a
+
+  - name: Push to repo
+    if: ${{ env.modified == 'true' }}
+    uses: CasperWA/push-protected@v2
+    with:
+      branch: ${{ inputs.branch }}
+      token: ${{ inputs.bp-pat }}
+      unprotect_reviews: true

--- a/.github/actions/action-version_task-commit/action.yml
+++ b/.github/actions/action-version_task-commit/action.yml
@@ -41,7 +41,7 @@ runs:
       uses: CasperWA/push-protected@v2
       with:
         branch: ${{ github.event.pull_request.base.ref }}
-        token: ${{ inputs.BP-PAT }}
+        token: ${{ inputs.bp-pat }}
         unprotect_reviews: true
 
     - name: Publish changelog


### PR DESCRIPTION
The current actions all have a step that push to a protected branch, but as part of a versioning workflow or composite action. This just adds an additional composite action that performs a `git status` check and pushes (if necessary) to a protected branch.