### PR TITLE
Fix composite action

### DIFF
--- a/.github/actions/action-setup_task-installPyProject/action.yml
+++ b/.github/actions/action-setup_task-installPyProject/action.yml
@@ -22,6 +22,10 @@ inputs:
     required: false
     default: false
     type: boolean
+  token:
+    description: Regular github token to be passed
+    required: true
+    type: string
 
 runs:
   using: composite
@@ -30,7 +34,8 @@ runs:
     - name: Clear cache
       if: github.event.pull_request.merged == true
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash
       run: |
         gh extension install actions/gh-actions-cache
 

--- a/.github/actions/action-version_task-commit/action.yml
+++ b/.github/actions/action-version_task-commit/action.yml
@@ -46,7 +46,7 @@ runs:
 
     - name: Publish changelog
       uses: release-drafter/release-drafter@v5
-      if: inputs.release
+      if: inputs.release == true
       with:
         commitish: ${{ inputs.branch }}
         publish: true


### PR DESCRIPTION
Added `shell:bash` and switched to `inputs` to pass along GITHUB_TOKEN for cache deletion. Also explicitly check that inputs.release is set to true.