### PR TITLE
fix poetry caching

### DIFF
--- a/.github/actions/action-setup_task-installPyProject/action.yml
+++ b/.github/actions/action-setup_task-installPyProject/action.yml
@@ -25,6 +25,7 @@ inputs:
 
 runs:
   using: composite
+  steps:
     - name: Clone repo
       uses: actions/checkout@v3
 
@@ -39,10 +40,8 @@ runs:
     - name: Install poetry
       uses: snok/install-poetry@v1
       if: inputs.manager == 'poetry' && steps.cached-manager.outputs.cache-hit != 'true'
-      id: setup-poetry
       with:
         virtualenvs-create: true
-        virtualenvs-in-project: true
 
     # Setup & configure Python
     - name: Setup python
@@ -52,20 +51,13 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: "${{ inputs.manager }}"
 
-    - name: Store pip cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}
-        restore-keys: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}
-
-    # Install dependencies with manager
+    # Install dependencies with manager, if necessary
     - name: Install dependencies
-      if: steps.setup-python.outputs.cache-hit != 'true' && steps.setup-poetry.outcome == 'success'
+      if: inputs.manager == 'poetry' && steps.setup-python.outputs.cache-hit != 'true'
       shell: bash
       run: poetry install --no-interaction --no-ansi --no-root --with dev
 
     - name: Install library
-      if: inputs.install-library && steps.setup-poetry.outcome == 'success'
+      if: inputs.manager == 'poetry' && inputs.install-library
       shell: bash
       run: poetry install --no-interaction --no-ansi

--- a/.github/workflows/workflow-release_task-deployPypi.yml
+++ b/.github/workflows/workflow-release_task-deployPypi.yml
@@ -45,7 +45,6 @@ jobs:
         id: setup-poetry
         with:
           virtualenvs-create: true
-          virtualenvs-in-project: true
 
       - name: Build and publish
         if: steps.setup-poetry.outcome == 'success'


### PR DESCRIPTION
- Removes previously added token for deletion (this was an extra, unnecessary step)
- Removes the cache action that generated ${{ runner.os }}-pip-${{ inputs.cache-id }}, this created an extra cache that contained nothing and was not used. This means that the library stuff solely relies on the python cache, which in the debugging logs appear to generate a new cache if the existing one is not within the appropriate scope.
- Changed the conditionals of the installation of dependencies and optional library from steps.setup-poetry.outputs.success to inputs.manager to check. Poetry should always be installed or restored from cache, and the former conditional would set to "skip" if poetry was restored from cache rather than success.
- Remove virtualenv creation witin project (allow for default path)