### PR TITLE
Use within-repo actions for versioning

### DIFF
--- a/.github/actions/action-version_task-updateReleaseVersion/action.yml
+++ b/.github/actions/action-version_task-updateReleaseVersion/action.yml
@@ -8,11 +8,6 @@
 name: Get previous project version
 description: Get the last version from project metadata for release
 inputs:
-  project-metadata:
-    description: Metadata file containing project version (e.g. pyproject.toml)
-    required: false
-    default: pyproject.toml
-    type: string
   bp-pat:
     description: Personal access token to update branch protection
     required: true

--- a/.github/workflows/workflow-release_task-publishGithub.yml
+++ b/.github/workflows/workflow-release_task-publishGithub.yml
@@ -5,6 +5,22 @@
 #   - main branch is protected
 name: Release package on GH
 on:
+  workflow_dispatch:
+    inputs:
+      comments:
+        description: Comments
+        required: false
+        type: string
+      project-metadata:
+        description: File containing project metadata (e.g. pyproject.toml)
+        required: false
+        default: pyproject.toml
+        type: string
+      pipeline-description:
+        description: Boolean flag to update pipeline_description.json
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       comments:

--- a/.github/workflows/workflow-release_task-publishGithub.yml
+++ b/.github/workflows/workflow-release_task-publishGithub.yml
@@ -22,7 +22,7 @@ on:
         default: false
         type: boolean
     secrets:
-      BP-PAT:
+      BP_PAT:
         required: true
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
         uses: khanlab/actions/.github/actions/action-version_task-updateReleaseVersion@v0.2.2
         with:
           project-metadata: ${{ inputs.project-metadata }}
-          bp-pat: ${{ secrets.BP-PAT }}
+          bp-pat: ${{ secrets.BP_PAT }}
 
       - name: Update version in ${{ inputs.project-metadata }}
         uses: jacobtomlinson/gha-find-replace@v3
@@ -60,6 +60,6 @@ jobs:
         uses: khanlab/actions/.github/actions/action-version_task-commit@v0.2.2
         with:
           version: ${{ steps.semver.outputs.new-version }}
-          bp-pat: ${{ secrets.BP-PAT }}
+          bp-pat: ${{ secrets.BP_PAT }}
           release: True
           branch: ${{ steps.semver.outputs.branch }}

--- a/.github/workflows/workflow-release_task-publishGithub.yml
+++ b/.github/workflows/workflow-release_task-publishGithub.yml
@@ -54,7 +54,6 @@ jobs:
         id: semver
         uses: khanlab/actions/.github/actions/action-version_task-updateReleaseVersion@v0.2.2
         with:
-          project-metadata: ${{ inputs.project-metadata }}
           bp-pat: ${{ secrets.BP_PAT }}
 
       - name: Update version in ${{ inputs.project-metadata }}

--- a/.github/workflows/workflow-version_task-semverGithub.yml
+++ b/.github/workflows/workflow-version_task-semverGithub.yml
@@ -18,7 +18,7 @@ on:
         default: false
         type: boolean
     secrets:
-      BP-PAT:
+      BP_PAT:
         required: true
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
         uses: khanlab/actions/.github/actions/action-version_task-updatePrereleaseVersion@v0.2.2
         with:
           project-metadata: ${{ inputs.project-metadata }}
-          bp-pat: ${{ secrets.BP-PAT }}
+          bp-pat: ${{ secrets.BP_PAT }}
 
       - name: Update version in ${{ inputs.project-metadata }}
         uses: jacobtomlinson/gha-find-replace@v3
@@ -51,4 +51,4 @@ jobs:
         uses: khanlab/actions/.github/actions/action-version_task-commit@v0.2.2
         with:
           version: ${{ steps.semver.outputs.new-version }}
-          bp-pat: ${{ secrets.BP-PAT }}
+          bp-pat: ${{ secrets.BP_PAT }}

--- a/.github/workflows/workflow-version_task-semverGithub.yml
+++ b/.github/workflows/workflow-version_task-semverGithub.yml
@@ -5,6 +5,8 @@
 #   - main branch is protected
 name: Bump version
 on:
+  pull_request_target:
+    types: [closed]
   workflow_call:
     inputs:
       project-metadata:

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ actions. If using a composite action within a reusable workflow, the
 `org/repo` must be specified, otherwise downstream usage will assume the
 composite action is stored within the downstream repository.
 
-An example of this can be seen below:
+An example of this can be seen below (note that this task always uses the
+version of the workflow found on the `main` branch):
 
 ```yaml
 - name: Grab previous version
   id: semver
-  uses: khanlab/actions/.github/actions/action-version_task-updatePrereleaseVersion@maint/semver
+  uses: khanlab/actions/.github/actions/action-version_task-updatePrereleaseVersion@main
   with:
     project-metadata: ${{ inputs.project-metadata }}
     bp-pat: ${{ secrets.BP_PAT }}
@@ -44,3 +45,7 @@ Naming of these files take inspiration from BIDS, but with a camel-case
 value scheme. Workflows are defined by the `workflow` entity, while composite
 actions are defined by the `action` entity. The intended task is defined by
 `task`.
+
+**NOTE: Prior to release, ensure all self-created actions within this repo**
+**(i.e. those within the `actions` directory) are set to the next anticipated**
+**version.**

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ An example of this can be seen below:
   uses: khanlab/actions/.github/actions/action-version_task-updatePrereleaseVersion@maint/semver
   with:
     project-metadata: ${{ inputs.project-metadata }}
-    bp-pat: ${{ secrets.BP-PAT }}
+    bp-pat: ${{ secrets.BP_PAT }}
 ```
 
 Naming of these files take inspiration from BIDS, but with a camel-case

--- a/release-drafter.yml
+++ b/release-drafter.yml
@@ -1,0 +1,28 @@
+---
+name-template: $RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
+filter-by-commitish: true
+template: |
+  ## Changes
+  $CHANGES
+categories:
+  - title: 🚀 Features
+    labels: [breaking, enhancement]
+  - title: 🐛 Bug Fixes
+    labels: [bug]
+  - title: 🧰 Maintenance
+    labels: [maintenance, test]
+  - title: 📝 Documentation
+    labels: [documentation]
+exclude-labels: [skip_changelog]
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: \<*_& # You can add  # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  # major:
+  #   labels:
+  #     - 'breaking'
+  minor:
+    labels: [breaking, enhancement]
+  patch:
+    labels: [maintenance, bug, test, documentation]
+  default: patch


### PR DESCRIPTION
This PR adds additional triggers and make the necessary changes to use some of the workflows (specifically the version bumping) within the repo to automate some of the processes.

TODO:
- [ ] Add metadata file to have public record of (pre-)versions.