### PR TITLE
Remove project-metadata input from release action

### DIFF
--- a/.github/actions/action-version_task-updateReleaseVersion/action.yml
+++ b/.github/actions/action-version_task-updateReleaseVersion/action.yml
@@ -8,11 +8,6 @@
 name: Get previous project version
 description: Get the last version from project metadata for release
 inputs:
-  project-metadata:
-    description: Metadata file containing project version (e.g. pyproject.toml)
-    required: false
-    default: pyproject.toml
-    type: string
   bp-pat:
     description: Personal access token to update branch protection
     required: true

--- a/.github/workflows/workflow-release_task-publishGithub.yml
+++ b/.github/workflows/workflow-release_task-publishGithub.yml
@@ -38,7 +38,6 @@ jobs:
         id: semver
         uses: khanlab/actions/.github/actions/action-version_task-updateReleaseVersion@v0.2.2
         with:
-          project-metadata: ${{ inputs.project-metadata }}
           bp-pat: ${{ secrets.BP-PAT }}
 
       - name: Update version in ${{ inputs.project-metadata }}


### PR DESCRIPTION
The `project-metadata` input is not necessary for the `updateRelease` action as it is not used. As a result, this has been removed. 

Note: Given how GHA works, this will cause an error to be thrown if the input is provided in a downstream workflow and should result in a "breaking" version bump despite it being a maintenance task.