### PR TITLE
Patch fix for composite actions inputs

### DIFF
--- a/.github/actions/action-general_task-commitProtected/action.yml
+++ b/.github/actions/action-general_task-commitProtected/action.yml
@@ -10,20 +10,18 @@ inputs:
   branch:
     description: Branch to commit changes to
     required: true
-    type: string
   commit-msg:
     description: Commit message
     required: true
-    type: string
   bp-pat:
     description: Personal access token to update branch protection
     required: true
-    type: string
 
 runs:
-  using: composite:
+  using: composite
   steps:
   - name: Check changes
+    shell: bash
     run: |
       gh_status=$(git status --porcelain)
       if [ -z "$gh_status" ]; then
@@ -34,6 +32,7 @@ runs:
   
   - name: Commit changes
     if: env.modified
+    shell: bash
     run: |
       git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
       git config --local user.name "github-actions[bot]"

--- a/.github/actions/action-setup_task-installPyProject/action.yml
+++ b/.github/actions/action-setup_task-installPyProject/action.yml
@@ -6,22 +6,18 @@ inputs:
   python-version:
     description: Python version to setup
     required: true
-    type: string
   cache-id:
     description: Reference id to define cache
     required: false
     default: ${{ github.event.pull_request.id || github.event.after }}
-    type: string
   manager:
     description: Dependency manager used (e.g. poetry)
     required: false
     default: "poetry"
-    type: string
   install-library:
-    description: Indicate whether project library should be installed
+    description: Boolean string to indicate if project library should be installed
     required: false
-    default: false
-    type: boolean
+    default: "false"
 
 runs:
   using: composite

--- a/.github/actions/action-version_task-commit/action.yml
+++ b/.github/actions/action-version_task-commit/action.yml
@@ -10,20 +10,16 @@ inputs:
   version:
     description: New / updated project version
     required: false
-    type: string
   bp-pat:
     description: Personal access token to update branch protection
     required: true
-    type: string
   release:
-    description: Boolean flag to indicate part of Github release workflow
+    description: Boolean string to indicate part of Github release workflow
     required: false
-    default: false
-    type: boolean
+    default: "false"
   branch:
     description: Triggering branch to checkout
     required: false
-    type: string
 
 runs:
   using: composite
@@ -46,7 +42,7 @@ runs:
 
     - name: Publish changelog
       uses: release-drafter/release-drafter@v5
-      if: inputs.release == true
+      if: inputs.release == 'true'
       with:
         commitish: ${{ inputs.branch }}
         publish: true

--- a/.github/actions/action-version_task-updatePrereleaseVersion/action.yml
+++ b/.github/actions/action-version_task-updatePrereleaseVersion/action.yml
@@ -12,11 +12,9 @@ inputs:
     description: Metadata file containing project version (e.g. pyproject.toml)
     required: false
     default: pyproject.toml
-    type: string
   bp-pat:
     description: Personal access token to update branch protection
     required: true
-    type: string
 outputs:
   new-version:
     description: Next pre-release version

--- a/.github/actions/action-version_task-updateReleaseVersion/action.yml
+++ b/.github/actions/action-version_task-updateReleaseVersion/action.yml
@@ -11,7 +11,6 @@ inputs:
   bp-pat:
     description: Personal access token to update branch protection
     required: true
-    type: string
 outputs:
   new-version:
     description: Next pre-release version

--- a/.github/workflows/workflow-release_task-publishGithub.yml
+++ b/.github/workflows/workflow-release_task-publishGithub.yml
@@ -76,5 +76,5 @@ jobs:
         with:
           version: ${{ steps.semver.outputs.new-version }}
           bp-pat: ${{ secrets.BP_PAT }}
-          release: True
+          release: "true"
           branch: ${{ steps.semver.outputs.branch }}


### PR DESCRIPTION
Parts of the release workflow were failing as input types were incorrect for composite actions. For reference, composite actions, at the time of this PR (Oct 2023) can only have string input types. Formerly, the workflow contained input types of boolean to indicate a flag. This PR makes the changes to pass along and compare string values.