### PR TITLE
Checkout appropriate branch in InstallPyProject

### DIFF
--- a/.github/actions/action-setup_task-installPyProject/action.yml
+++ b/.github/actions/action-setup_task-installPyProject/action.yml
@@ -24,6 +24,8 @@ runs:
   steps:
     - name: Clone repo
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.base_ref }}
 
     # Setup & configure dependency manager
     - name: Cache manager installation


### PR DESCRIPTION
The current workflow will always default to checking out the `main`/`master` branch (see https://github.com/afids/afids-validator/actions/runs/6643788653). This PR adds the reference to checkout the PR branch, or if it does not exist, the `main`/`master` branch.

This is really only an issue if dependencies have changed in submitted PRs, which can cause tests to fail.

Resolves #24.