### PR TITLE
Report installed python version in installpyproject

### DIFF
--- a/.github/actions/action-setup_task-installPyProject/action.yml
+++ b/.github/actions/action-setup_task-installPyProject/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Boolean string to indicate if project library should be installed
     required: false
     default: "false"
+outputs:
+  python-version:
+    description: "Resolved python version as reported by setup-python"
+    value: ${{ steps.setup-python.outputs.python-version }}
 
 runs:
   using: composite


### PR DESCRIPTION
Turns out this isn't necessary to consume the resolved python version (as `steps.setup-py` does seem to be implicitly available in the parent workflow), but this makes things a little more explicit and plays better with the github actions intellisense