### PR TITLE
Expose more settings in pyproject install

### DIFF
--- a/.github/actions/action-setup_task-installPyProject/action.yml
+++ b/.github/actions/action-setup_task-installPyProject/action.yml
@@ -7,17 +7,42 @@ inputs:
     description: Python version to setup
     required: true
   cache-id:
-    description: Reference id to define cache
+    description: |
+      Reference id to define cache. This id should be unique to the commit or PR
+      (e.g. the PR id or git hash)
     required: false
     default: ${{ github.event.pull_request.id || github.event.after }}
+  cache-key:
+    description: |
+      Unique key to identify cache. This id should be unique to the job step
+      (e.g. 'test', 'docs')
+    required: false
   manager:
     description: Dependency manager used (e.g. poetry)
     required: false
     default: "poetry"
   install-library:
-    description: Boolean string to indicate if project library should be installed
+    description: |
+      indicate if project library should be installed. 'true' installs from
+      cloned repo, false skips install
     required: false
     default: "false"
+  install-deps-with:
+    description: |
+      install specified groups with dependency installation. Ignored if
+      install-deps-only is provided
+    required: false
+    default: dev
+  install-deps-only:
+    description: install only the specified dependency groups
+    required: false
+  sparse-checkout:
+    description: enables sparse-checkout on actions/checkout
+    required: false
+  sparse-checkout-cone-mode:
+    description: |
+      Specifies whether to use cone-mode when doing a sparse checkout.
+    required: false
 outputs:
   python-version:
     description: "Resolved python version as reported by setup-python"
@@ -27,9 +52,11 @@ runs:
   using: composite
   steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.base_ref }}
+        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: ${{ inputs.sparse-checkout-cone-mode }}
 
     # Setup & configure dependency manager
     - name: Cache manager installation
@@ -46,18 +73,40 @@ runs:
         virtualenvs-create: true
 
     # Setup & configure Python
+    - name: Create cache-key file
+      shell: bash
+      run: echo "${{ inputs.cache-key }}" >> .git/x-gh-cache-key
+
     - name: Setup python
       uses: actions/setup-python@v4
       id: setup-python
       with:
         python-version: ${{ inputs.python-version }}
         cache: "${{ inputs.manager }}"
+        cache-dependency-path: |
+          **/poetry.lock
+          .git/x-gh-cache-key
 
     # Install dependencies with manager, if necessary
-    - name: Install dependencies
-      if: inputs.manager == 'poetry' && steps.setup-python.outputs.cache-hit != 'true'
+    - name: Install dependencies (with)
+      if: >
+        inputs.manager == 'poetry' &&
+        steps.setup-python.outputs.cache-hit != 'true' &&
+        ! inputs.install-deps-only
       shell: bash
-      run: poetry install --no-interaction --no-ansi --no-root --with dev --all-extras
+      run: >
+        poetry install --no-interaction --no-ansi --no-root
+        --with ${{ inputs.install-deps-with }} --all-extras
+
+    - name: Install dependencies (only)
+      if: >
+        inputs.manager == 'poetry' &&
+        steps.setup-python.outputs.cache-hit != 'true' &&
+        inputs.install-deps-only
+      shell: bash
+      run:  >
+        poetry install --no-interaction --no-ansi --no-root
+        --only ${{ inputs.install-deps-only }}
 
     - name: Install library
       if: inputs.manager == 'poetry' && inputs.install-library == 'true'


### PR DESCRIPTION
[Motivating PR](https://github.com/khanlab/snakebids/pull/357)

Allow specification of --with and --only in poetry install. The two are considered mutually exclusive, so if "only" is given, "with" is ignored.

Allow sparse checkouts. This doesn't actually get used in the above PR, but it's just transparently passed on to actions/checkout so I didn't think it caused harm.

Create an additional cache-key that gets incorporated into the setup-python cache, allowing the creation of mutually exclusive caches in the same workflow context. Note that this results in a spurious warning, as `setup-python` assumes all cache-dep-files are poetry lock files in poetry mode, and so it looks for pyproject files at all of the given locations. No way around AFAIK.