### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. 
+    # (You don't need to specify `/.github/workflows` for `directory`. 
+    # You can use `directory: "/"`.)
+    directory: "/"
+    # Run on first of each month
+    schedule:
+      interval: "monthly"
+    # Group to submit a single PR if possible
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Taken from https://github.com/pyenv/pyenv/pull/2863, this PR adds a dependabot config to automatically check and update out-of-date GitHub actions (e.g. `actions/checkout@v3` -> `actions/checkout@v4`). This should help with addressing some of the warnings that pop-up with out-of-date node versions as the actions we use are updated. Once merged, will need to turn on "Dependabot version updates" in security settings.
_(This also makes #7 obsolete)_

Should note that this ignores actions & workflows referenced locally, so any version updates to locally created actions / workflows will still need to be manually updated within the repo.

Can see this in action on my fork of this repo as I turned had turned it on see how it would work:
https://github.com/kaitj/actions/pull/2 

@pvandyken - pinging so you are made aware of this as it seems like a useful thing to have across different repos (and should probably just be included by default in templates).

I'll leave this PR open for a few days before merging this in so that the dependabot can do its thing.