### PR TITLE
Add non-default actions paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Workflow
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. 
     # (You don't need to specify `/.github/workflows` for `directory`. 
@@ -9,6 +10,52 @@ updates:
     schedule:
       interval: "monthly"
     # Group to submit a single PR if possible
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Actions
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/action-general_task-commitProtected"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/action-setup_task-installPyProject"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/action-version_task-commit"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/action-version_task-updatePrereleaseVersion"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/action-version_task-updateReleaseVersion"
+    schedule:
+      interval: "monthly"
     groups:
       github-actions:
         patterns:

--- a/project.toml
+++ b/project.toml
@@ -1,6 +1,6 @@
 [project]
 name = "khanlab_actions"
-version = "0.3.2"
+version = "0.3.6"
 description = "Reusable Github actions workflows"
 authors = [{ name = "Jason Kai", email = "tkai@uwo.ca" }]
 readme = "README.md"


### PR DESCRIPTION
This adds in package-ecosystems for the non-default paths (e.g. `.github/actions/...`). Currently need to specify each unique path ... waiting for implementation of recursive searching or wildcards.