### PR TITLE
Update workflow-release_task-deployDocker.yml

### DIFF
--- a/.github/workflows/workflow-release_task-deployDocker.yml
+++ b/.github/workflows/workflow-release_task-deployDocker.yml
@@ -37,11 +37,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout latest release tag
-        run: |
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          git checkout $LATEST_TAG
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Was always checking out latest tag, even when building from a branch (this breaks the previous behaviour in the hippunfold deployment workflow prior to Jan 2024)...