### PR TITLE
Update checkout step to use release tag from event

### DIFF
--- a/.github/workflows/workflow-release_task-deployDocker.yml
+++ b/.github/workflows/workflow-release_task-deployDocker.yml
@@ -38,10 +38,12 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout latest release tag
+        if: github.event_name == 'release'
         run: |
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          git checkout $LATEST_TAG
+          LATEST_TAG=${{ github.event.release.tag_name }}
+          git checkout "$LATEST_TAG"
 
+    
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
was always pulling latest release even when running on a diff branch..